### PR TITLE
Correção contingência SVC

### DIFF
--- a/src/main/java/br/com/swconsultoria/cte/util/WebServiceCteUtil.java
+++ b/src/main/java/br/com/swconsultoria/cte/util/WebServiceCteUtil.java
@@ -67,7 +67,7 @@ public class WebServiceCteUtil {
                     secao = "CTe_SVRS_" + sufixoAmbiente;
                 } else {
                     //SVC RS
-                    secao = "CTe_SVSP_" + sufixoAmbiente;
+                    secao = "CTe_SVC-SP_" + sufixoAmbiente;
                 }
             }
 


### PR DESCRIPTION
Apenas corrigi a seção que busca o servidor virtual de São Paulo para contingência, pois não exite nenhum link no .ini iniciando com "CTe_SVSP_".
Testei a emissão em Santa Catarina, e desta maneira funcionou.